### PR TITLE
newchain testnet node deployment guide

### DIFF
--- a/newchain-testnet-node-deployment-guide-en.md
+++ b/newchain-testnet-node-deployment-guide-en.md
@@ -1,0 +1,97 @@
+# NewChain TestNet Deployment Guide
+
+## 1. System requirements
+
+### 1.1 Recommended specifications
+
+  - System OS: Ubuntu 18.04 LTS 64-bit or Ubuntu 16.04 LTS 64-bit
+  - Processor: 2-core CPU
+  - Memory: 8GB RAM
+  - Storage: 200GB free space SSD for testnet
+  - Internet: Public IP
+
+For server requirements, please refer to AWS m5a.large or Alibaba Cloud ecs.t5
+
+### 1.2 System configuration
+
+  - System data disk: `/data` directory is the mount point of the system data disk
+  - Firewall: The firewall needs to open port 38311 for UDP and TCP, and port 8801 for TCP
+
+## 2. Clearing date
+
+**If your computer has never run the NewChain TestNet node, please skip these steps.**
+
+### 2.1 Clear working directory
+
+```bash
+$ rm -rf ~/newchain
+```
+
+### 2.2 Delete data directory
+
+```bash
+$ sudo rm -rf /data/newchain/
+```
+
+## 3. Deploying a read-only node
+
+### 3.1 Create a working directory and enter it
+
+```bash
+$ mkdir -p newchain && cd newchain
+```
+
+### 3.2 Fetch the `newchain.sh` script and run it
+
+```bash
+$ curl -L https://release.cloud.diynova.com/newton/newchain-deploy/testnet/newchain.sh | sudo bash
+```
+
+### 3.3 View the running log of NewChain
+
+```bash
+$ sudo supervisorctl tail -f newchain stderr
+```
+
+### 3.4 Make sure the synchronized block height is consistent with the NewExplorer (<a href="https://explorer.testnet.newtonproject.org/">Testnet</a>) latest block height
+
+## 4. Deoloying a ledger node
+
+### 4.1 Execute following command to create miner account
+
+```bash
+$ cd /data/newchain/testnet/ && curl -L https://release.cloud.diynova.com/newton/newchain-deploy/testnet/newchain-mine.sh -o newchain-mine.sh && chmod +x newchain-mine.sh && ./newchain-mine.sh
+```
+
+### 4.2 Set keystore password
+
+Set keystore password twice and keep keystore, password and miner address. The password shall not be void.
+
+#### 4.2.1 Backup keystore
+
+Run following code to get keystore and store it securely
+
+```bash
+$ cat /data/newchain/testnet/nodedata/keystore/*
+```
+
+#### 4.2.2 Backup keystore password
+
+Run following code to get password and store it securely
+
+```bash
+$ cat /data/newchain/testnet/password.txt
+```
+
+You are responsible for storing your keystore and password safely. It’s important to keep your digital assets safe, just like you would your physical assets.
+
+### 4.3 Click the blow link to submit a issue, fill the required information and wait for the existing ledger node to be approved
+
+[Apply for testnet ledger node](https://github.com/newtonproject/newchain-nodes/issues/new?assignees=xiawu&labels=testnet&template=apply-testnet-miner-en.md&title=%3Cnode+name%3E+Apply+for+testnet+ledger+node)
+
+### 4.4 Verify if your own node has become a ledger node
+
+```bash
+$ /data/newchain/testnet/bin/geth attach /data/newchain/testnet/nodedata/geth.ipc --exec 'clique.getSigners()'
+```
+

--- a/newchain-testnet-node-deployment-guide.md
+++ b/newchain-testnet-node-deployment-guide.md
@@ -1,6 +1,6 @@
 # NewChain测试网节点部署方法
 
-### 一. 系统需求
+## 一. 系统需求
 
 ### 1.1 最小配置
 
@@ -14,58 +14,58 @@
 
 ### 1.2 系统配置
 
-- 系统数据盘挂载： /data 目录为系统数据盘的挂载点
-- 防火墙： 防火墙需要打开 UDP 和 TCP 的 38311 端口，以及 TCP 的 8801 端口
+- 系统数据盘挂载：`/data` 目录为系统数据盘的挂载点
+- 防火墙：防火墙需要打开 UDP 和 TCP 的 38311 端口，以及 TCP 的 8801 端口
 
-### 二. 清除数据
+## 二. 清除数据
 
 **如果你的机器没有运行过NewChain TestNet节点，请忽略这步。**
 
-#### 1. 清除工作目录
+### 2.1 清除工作目录
 
 ```bash
 $ rm -rf ~/newchain
 ```
 
-#### 2. 删除数据目录
+### 2.2 删除数据目录
 
 ```bash
 $ sudo rm -rf /data/newchain/
 ```
 
-### 三. 部署只读节点
+## 三. 部署只读节点
 
-#### 1. 创建工作目录
+### 3.1 创建工作目录
 
 ```bash
 $ mkdir -p ~/newchain && cd ~/newchain
 ```
 
-#### 2. 获取安装脚本程序`newchain.sh`并运行
+### 3.2 获取安装脚本程序`newchain.sh`并运行
 
 ```bash
 $ curl -L https://release.cloud.diynova.com/newton/newchain-deploy/testnet/newchain.sh | sudo bash
 ```
 
-#### 3. 查看 NewChain 运行日志
+### 3.3 查看 NewChain 运行日志
 
 ```bash
 $ sudo supervisorctl tail -f newchain stderr
 ```
 
-#### 4. 确认已经同步到最新块
+### 3.4 确认已经同步到最新块
 
 确认日志中已同步的块和浏览器中最新块一致，TestNet浏览器：https://explorer.testnet.newtonproject.org/
 
-### 四. 部署记账节点
+## 四. 部署记账节点
 
-#### 1. 运行下面命令，创建矿工账户
+### 4.1 运行下面命令，创建矿工账户
 
 ```bash
 $ cd /data/newchain/testnet/ && curl -L https://release.cloud.diynova.com/newton/newchain-deploy/testnet/newchain-mine.sh -o newchain-mine.sh && chmod +x newchain-mine.sh && ./newchain-mine.sh
 ```
 
-#### 2. 设置keystore密码
+### 4.2 设置keystore密码
 
 运行完1中的命令，会提示你输入两次keystore密码，备份好矿工地址、keystore密码和keystore文件。keystore文件在 `/data/newchain/testnet/nodedata/keystore/` 目录下。
 
@@ -89,11 +89,11 @@ $ cd /data/newchain/testnet/ && curl -L https://release.cloud.diynova.com/newton
 
   备份好密码，切勿泄露给任何人。
 
-#### 3. 点击下面链接提交"申请成为测试网记账节点"的issue
+### 4.3 点击下面链接提交"申请成为测试网记账节点"的issue
 
 ​	[申请成为测试网记账节点](https://github.com/newtonproject/newchain-nodes/issues/new?assignees=xiawu&labels=testnet&template=apply-testnet-miner-cn.md&title=%3C%E8%8A%82%E7%82%B9%E5%90%8D%E7%A7%B0%3E+%E7%94%B3%E8%AF%B7%E6%88%90%E4%B8%BA%E6%B5%8B%E8%AF%95%E7%BD%91%E8%AE%B0%E8%B4%A6%E8%8A%82%E7%82%B9)
 
-#### 4. 等待其他节点批准加入，你可以通过下面命令查看是否成为记账节点
+### 4.4 等待其他节点批准加入，你可以通过下面命令查看是否成为记账节点
 
 ```bash
 $ /data/newchain/testnet/bin/geth attach /data/newchain/testnet/nodedata/geth.ipc --exec 'clique.getSigners()'


### PR DESCRIPTION
1. rename newchian-testnet-node-dployment-guide.md to newchain-testnet-node-deployment.md and reformat it; 
2. add newchain-testnet-node-deployment-guide-en.md, the english version of newchain-test-node-deployment.md.